### PR TITLE
Fix 'static' is not a valid attribute for a TaskInclude (Ansible 2.8)

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,8 +4,7 @@
 # CATALINA_BASE directory from CATALINA_HOME
 #
 
-- { include_tasks: xmlx-package-Debian.yml, when: "ansible_os_family == 'Debian'", static: false }
-- { include_tasks: xmlx-package-RedHat.yml, when: "ansible_os_family == 'RedHat'", static: false }
+- { include_tasks: "xmlx-package-{{ ansible_os_family }}.yml", when: "ansible_os_family == 'Debian' or ansible_os_family == 'RedHat'" }
 
 - name: install Tomcat prerequisite
   include_tasks: install-prerequisite.yml


### PR DESCRIPTION
```
ERROR! 'static' is not a valid attribute for a TaskInclude

The error appears to be in '/roles/kami911.tomcat/tasks/main.yml': line 7, column 3, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

- { include_tasks: xmlx-package-Debian.yml, when: "ansible_os_family == 'Debian'", static: false }
  ^ here
```