### PR TITLE
Update prepare-catalina-base.yml

### DIFF
--- a/tasks/prepare-catalina-base.yml
+++ b/tasks/prepare-catalina-base.yml
@@ -141,6 +141,8 @@
   template:
     src: '{{ item }}.j2'
     dest: '{{ tomcat_catalina_base }}/conf/{{ item }}'
+    owner: "{{ tomcat_system_user }}"
+    group: "{{ tomcat_system_group }}"
     mode: '0640'
   with_items:
     - 'context.xml'


### PR DESCRIPTION
The tomcat-user needs access to these file, otherwise it won't start:

```
Nov 20, 2020 11:35:46 AM org.apache.catalina.startup.Catalina load
WARNING: Unable to load server configuration from [/opt/tomcat/tomcat/conf/server.xml]
Nov 20, 2020 11:35:46 AM org.apache.catalina.startup.Catalina load
WARNING: Permissions incorrect, read permission is not allowed on the file.
Nov 20, 2020 11:35:46 AM org.apache.catalina.startup.Catalina start
SEVERE: Cannot start server. Server instance is not configured.
```